### PR TITLE
Added code to check for existence of html or text body when attachments ...

### DIFF
--- a/lib/aws/ses/send_email.rb
+++ b/lib/aws/ses/send_email.rb
@@ -96,8 +96,9 @@ module AWS
       # @option args [String] :to alias for :destinations
       # @return [Response]
       def send_raw_email(mail, args = {})
-        message = mail.is_a?(Hash) ? Mail.new(mail).to_s : mail.to_s
-        package = { 'RawMessage.Data' => Base64::encode64(message) }
+        message = mail.is_a?(Hash) ? Mail.new(mail) : mail
+        raise ArgumentError, "Attachment provided without message body" if message.has_attachments? && message.text_part.nil? && message.html_part.nil?
+        package = { 'RawMessage.Data' => Base64::encode64(message.to_s) }
         package['Source'] = args[:from] if args[:from]
         package['Source'] = args[:source] if args[:source]
         if args[:destinations]

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -54,3 +54,9 @@ class Test::Unit::TestCase
     Base.new(:access_key_id=>'123', :secret_access_key=>'abc')
   end
 end
+
+# Deals w/ http://github.com/thoughtbot/shoulda/issues/issue/117, see 
+# http://stackoverflow.com/questions/3657972/nameerror-uninitialized-constant-testunitassertionfailederror-when-upgradin
+unless defined?(Test::Unit::AssertionFailedError)
+  Test::Unit::AssertionFailedError = ActiveSupport::TestCase::Assertion
+end

--- a/test/send_email_test.rb
+++ b/test/send_email_test.rb
@@ -46,6 +46,24 @@ class SendEmailTest < Test::Unit::TestCase
       assert_equal 'xyz-123', result.request_id
     end
     
+    should 'throw ArgumentException when attachment supplied without a body' do
+      #mock_connection(@base, :body => %{
+      #  <SendRawEmailResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
+      #    <SendRawEmailResult>
+      #      <MessageId>abc-123</MessageId>
+      #    </SendRawEmailResult>
+      #    <ResponseMetadata>
+      #      <RequestId>xyz-123</RequestId>
+      #    </ResponseMetadata>
+      #  </SendRawEmailResponse>
+      #})
+      message = Mail.new({:from => 'jon@example.com', :to => 'dave@example.com', :subject => 'Subject1'})
+      message.attachments['foo'] = { :mime_type => 'application/csv', :content => '1,2,3' }
+      assert_raise ArgumentError do
+        result = @base.send_raw_email message
+      end
+    end
+
     should 'send a raw e-mail with a hash object' do
       mock_connection(@base, :body => %{
         <SendRawEmailResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">


### PR DESCRIPTION
Hello,

This is only my second pull request, so I apologize if I'm not following proper etiquette! 

I opened Issue #29 two days ago - the problem is that SES gets angry when you try to send an e-mail with an attachment and no other body text. Rather than do something doofy like create a default text body, I've tweaked the code to throw an ArgumentError with more descriptive text when someone tries to do this.

The code doesn't depend on ActionMailer, and there's an accompanying test. Let me know if you have any questions!

BTW - very nice work on this gem. It's been a lifesaver!
- Mike
