### PR TITLE
Fixed Gemfile listing to point to github since ruby-gems is out of date

### DIFF
--- a/README.erb
+++ b/README.erb
@@ -20,7 +20,7 @@ This gem is compatible with Rails >= 3.0.0 and Rails 2.3.x
 
 To use, first add the gem to your Gemfile:
 
-    gem "aws-ses", "~> 0.5.0", :require => 'aws/ses'
+    gem 'aws-ses', '~> 0.5.0', :require => 'aws/ses', :github => 'drewblas/aws-ses'
     
 == For Rails 3.x
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -130,7 +130,7 @@ This gem is compatible with Rails >= 3.0.0 and Rails 2.3.x
 
 To use, first add the gem to your Gemfile:
 
-    gem "aws-ses", "~> 0.5.0", :require => 'aws/ses'
+    gem 'aws-ses', '~> 0.5.0', :require => 'aws/ses', :github => 'drewblas/aws-ses'
     
 == For Rails 3.x
 


### PR DESCRIPTION
The most recent version in ruby-gems is 0.4.4 so the current line in the README will fail with:

```
Could not find gem 'aws-ses (~> 0.5.0) ruby' in the gems available on this machine.
```

This fix will ensure we're always pointed to the right place even if ruby-gems isn't updated.
