### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/aws/ses/base.rb
+++ b/lib/aws/ses/base.rb
@@ -35,7 +35,7 @@ module AWS #:nodoc:
     # @param [Boolean] urlencode whether or not to url encode the result., true or false
     # @return [String] the signed and encoded string.
     def SES.encode(secret_access_key, str, urlencode=true)
-      digest = OpenSSL::Digest::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
       b64_hmac =
         Base64.encode64(
           OpenSSL::HMAC.digest(digest, secret_access_key, str)).gsub("\n","")


### PR DESCRIPTION
OpenSSL::Digest::Digest has been there from very ancient era such as Ruby 1.8 https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and finally was deprecated recently. https://github.com/ruby/ruby/pull/446
