### PR TITLE
VERIFY_NONE is insecure, and no longer necessary

### DIFF
--- a/lib/aws/ses/base.rb
+++ b/lib/aws/ses/base.rb
@@ -130,10 +130,6 @@ module AWS #:nodoc:
                                   proxy.password).new(options[:server], @port)
 
         @http.use_ssl = @use_ssl
-
-        # Don't verify the SSL certificates.  Avoids SSL Cert warning in log on every GET.
-        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
       end
       
       def connection


### PR DESCRIPTION
I don't get any warnings with VERIFY_PEER, so default to that since it is secure and doesn't seem to have any downsides.