### PR TITLE
Delivery method option region added to generate accurate message_id

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,8 @@ To connect to a different one, just pass it as a parameter to the AWS::SES::Base
   ses = AWS::SES::Base.new(
     :access_key_id     => 'abc', 
     :secret_access_key => '123',
-    :server => 'email.eu-west-1.amazonaws.com'
+    :server => 'email.eu-west-1.amazonaws.com',
+    :region => 'eu-west-1'
   )
 
 == Send E-mail

--- a/README.rdoc
+++ b/README.rdoc
@@ -29,7 +29,7 @@ To connect to a different one, just pass it as a parameter to the AWS::SES::Base
     :access_key_id     => 'abc', 
     :secret_access_key => '123',
     :server => 'email.eu-west-1.amazonaws.com',
-    :region => 'eu-west-1'
+    :message_id_domain => 'eu-west-1.amazonses.com'
   )
 
 == Send E-mail
@@ -134,7 +134,6 @@ will return:
         "DeliveryAttempts"=>"3",
         "Rejects"=>"0",
         "Complaints"=>"0"}]
-
 
 == Rails
 

--- a/lib/aws/ses/base.rb
+++ b/lib/aws/ses/base.rb
@@ -26,8 +26,10 @@ module AWS #:nodoc:
   #   ses = AWS::SES::Base.new(
   #     :access_key_id     => 'abc', 
   #     :secret_access_key => '123',
-  #     :server => 'email.eu-west-1.amazonaws.com'
+  #     :server => 'email.eu-west-1.amazonaws.com',
+  #     :message_id_domain => 'eu-west-1.amazonses.com'
   #   )
+  #
 
   module SES
     
@@ -35,7 +37,7 @@ module AWS #:nodoc:
     
     DEFAULT_HOST = 'email.us-east-1.amazonaws.com'
 
-    DEFAULT_REGION = 'us-east-1'
+    DEFAULT_MESSAGE_ID_DOMAIN = 'email.amazonses.com'
     
     USER_AGENT = 'github-aws-ses-ruby-gem'
     
@@ -75,7 +77,7 @@ module AWS #:nodoc:
       include SendEmail
       include Info
       
-      attr_reader :use_ssl, :server, :proxy_server, :port, :region
+      attr_reader :use_ssl, :server, :proxy_server, :port, :message_id_domain
       attr_accessor :settings
 
       # @option options [String] :access_key_id ("") The user's AWS Access Key ID
@@ -84,7 +86,7 @@ module AWS #:nodoc:
       # @option options [String] :server ("email.us-east-1.amazonaws.com") The server API endpoint host
       # @option options [String] :proxy_server (nil) An HTTP proxy server FQDN
       # @option options [String] :user_agent ("github-aws-ses-ruby-gem") The HTTP User-Agent header value
-      # @option options [String] :region ("us-east-1") Region of AWS endpoint, to build accurate message-id
+      # @option options [String] :message_id_domain ("us-east-1.amazonses.com") Domain used to build message_id header
       # @return [Object] the object.
       def initialize( options = {} )
 
@@ -92,14 +94,14 @@ module AWS #:nodoc:
                     :secret_access_key => "",
                     :use_ssl => true,
                     :server => DEFAULT_HOST,
-                    :region => DEFAULT_REGION,
+                    :message_id_domain => DEFAULT_MESSAGE_ID_DOMAIN,
                     :path => "/",
                     :user_agent => USER_AGENT,
                     :proxy_server => nil
                     }.merge(options)
 
         @server = options[:server]
-        @region = options[:region]
+        @message_id_domain = options[:message_id_domain]
         @proxy_server = options[:proxy_server]
         @use_ssl = options[:use_ssl]
         @path = options[:path]

--- a/lib/aws/ses/base.rb
+++ b/lib/aws/ses/base.rb
@@ -34,6 +34,8 @@ module AWS #:nodoc:
     API_VERSION = '2010-12-01'
     
     DEFAULT_HOST = 'email.us-east-1.amazonaws.com'
+
+    DEFAULT_REGION = 'us-east-1'
     
     USER_AGENT = 'github-aws-ses-ruby-gem'
     
@@ -73,7 +75,7 @@ module AWS #:nodoc:
       include SendEmail
       include Info
       
-      attr_reader :use_ssl, :server, :proxy_server, :port
+      attr_reader :use_ssl, :server, :proxy_server, :port, :region
       attr_accessor :settings
 
       # @option options [String] :access_key_id ("") The user's AWS Access Key ID
@@ -82,6 +84,7 @@ module AWS #:nodoc:
       # @option options [String] :server ("email.us-east-1.amazonaws.com") The server API endpoint host
       # @option options [String] :proxy_server (nil) An HTTP proxy server FQDN
       # @option options [String] :user_agent ("github-aws-ses-ruby-gem") The HTTP User-Agent header value
+      # @option options [String] :region ("us-east-1") Region of AWS endpoint, to build accurate message-id
       # @return [Object] the object.
       def initialize( options = {} )
 
@@ -89,12 +92,14 @@ module AWS #:nodoc:
                     :secret_access_key => "",
                     :use_ssl => true,
                     :server => DEFAULT_HOST,
+                    :region => DEFAULT_REGION,
                     :path => "/",
                     :user_agent => USER_AGENT,
                     :proxy_server => nil
                     }.merge(options)
 
         @server = options[:server]
+        @region = options[:region]
         @proxy_server = options[:proxy_server]
         @use_ssl = options[:use_ssl]
         @path = options[:path]

--- a/lib/aws/ses/send_email.rb
+++ b/lib/aws/ses/send_email.rb
@@ -101,7 +101,7 @@ module AWS
 
         raw_email = build_raw_email(message, args)
         result = request('SendRawEmail', raw_email)
-        message.message_id = "#{result.parsed['SendRawEmailResult']['MessageId']}@#{region}.amazonses.com"
+        message.message_id = "#{result.parsed['SendRawEmailResult']['MessageId']}@#{message_id_domain}"
         result
       end
 

--- a/lib/aws/ses/send_email.rb
+++ b/lib/aws/ses/send_email.rb
@@ -101,7 +101,7 @@ module AWS
 
         raw_email = build_raw_email(message, args)
         result = request('SendRawEmail', raw_email)
-        message.message_id = "#{result.parsed['SendRawEmailResult']['MessageId']}@email.amazonses.com"
+        message.message_id = "#{result.parsed['SendRawEmailResult']['MessageId']}@#{region}.amazonses.com"
         result
       end
 


### PR DESCRIPTION
I've added aws region to the delivery_method_options so that the message_id generated matches the one received by email client.

Before: "#{message_id}@emails.amazonses.com"
After: "#{message_id}@#{region}.amazonses.com"
