### PR TITLE
Default to sig v4

### DIFF
--- a/lib/aws/ses/base.rb
+++ b/lib/aws/ses/base.rb
@@ -42,7 +42,9 @@ module AWS #:nodoc:
     DEFAULT_HOST = 'email.us-east-1.amazonaws.com'
 
     DEFAULT_MESSAGE_ID_DOMAIN = 'email.amazonses.com'
-    
+
+    DEFAULT_SIGNATURE_VERSION = 4
+
     USER_AGENT = 'github-aws-ses-ruby-gem'
     
     # Encodes the given string with the secret_access_key by taking the
@@ -107,10 +109,11 @@ module AWS #:nodoc:
                     :path => "/",
                     :user_agent => USER_AGENT,
                     :proxy_server => nil,
-                    :region => DEFAULT_REGION
+                    :region => DEFAULT_REGION,
+                    :signature_version => DEFAULT_SIGNATURE_VERSION,
                     }.merge(options)
 
-        @signature_version = options[:signature_version] || 2
+        @signature_version = options[:signature_version]
         @server = options[:server]
         @message_id_domain = options[:message_id_domain]
         @proxy_server = options[:proxy_server]
@@ -194,7 +197,7 @@ module AWS #:nodoc:
       end
 
       # Set the Authorization header using AWS signed header authentication
-      def get_aws_auth_param(timestamp, secret_access_key, action = '', signature_version = 2)
+      def get_aws_auth_param(timestamp, secret_access_key, action = '', signature_version = self.DEFAULT_SIGNATURE_VERSION)
         raise(ArgumentError, "signature_version must be `2` or `4`") unless signature_version == 2 || signature_version == 4
         encoded_canonical = SES.encode(secret_access_key, timestamp, false)
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -48,7 +48,7 @@ class BaseTest < Test::Unit::TestCase
         secret_access_key: aws_secret_access_key
     )
 
-    assert_equal 'AWS3-HTTPS AWSAccessKeyId=fake_aws_key_id, Algorithm=HmacSHA256, Signature=eHh/cPIJJUc1+RMCueAi50EPlYxkZNXMrxtGxjkBD1w=', base.get_aws_auth_param(timestamp.httpdate, aws_secret_access_key)
+    assert_equal 'AWS3-HTTPS AWSAccessKeyId=fake_aws_key_id, Algorithm=HmacSHA256, Signature=eHh/cPIJJUc1+RMCueAi50EPlYxkZNXMrxtGxjkBD1w=', base.get_aws_auth_param(timestamp.httpdate, aws_secret_access_key, 'DescribeRegions', 2)
   end
 
   def test_ses_authorization_header_v4
@@ -58,13 +58,11 @@ class BaseTest < Test::Unit::TestCase
     ::Timecop.freeze(time)
 
     base = ::AWS::SES::Base.new(
-        server:            'ec2.amazonaws.com',
-        signature_version: 4,
         access_key_id:     aws_access_key_id,
         secret_access_key: aws_secret_access_key
     )
 
-    assert_equal 'AWS4-HMAC-SHA256 Credential=fake_aws_key_id/20200702/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=c0465b36efd110b14a1c6dcca3e105085ed2bfb2a3fd3b3586cc459326ab43aa', base.get_aws_auth_param(time.httpdate, aws_secret_access_key, 'DescribeRegions', 4)
+    assert_equal 'AWS4-HMAC-SHA256 Credential=fake_aws_key_id/20200702/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=b872601457070ab98e7038bdcd4dc1f5eab586ececf9908525474408b0740515', base.get_aws_auth_param(time.httpdate, aws_secret_access_key, 'DescribeRegions', 4)
     Timecop.return
   end
 
@@ -75,13 +73,12 @@ class BaseTest < Test::Unit::TestCase
     ::Timecop.freeze(time)
 
     base = ::AWS::SES::Base.new(
-        server:            'email.us-east-1.amazonaws.com',
-        signature_version: 4,
+        server:            'ec2.amazonaws.com',
         access_key_id:     aws_access_key_id,
         secret_access_key: aws_secret_access_key
     )
 
-    assert_equal 'AWS4-HMAC-SHA256 Credential=fake_aws_key_id/20200702/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=b872601457070ab98e7038bdcd4dc1f5eab586ececf9908525474408b0740515', base.get_aws_auth_param(time.httpdate, aws_secret_access_key, 'DescribeRegions', 4)
+    assert_equal 'AWS4-HMAC-SHA256 Credential=fake_aws_key_id/20200702/us-east-1/ec2/aws4_request, SignedHeaders=host;x-amz-date, Signature=c0465b36efd110b14a1c6dcca3e105085ed2bfb2a3fd3b3586cc459326ab43aa', base.get_aws_auth_param(time.httpdate, aws_secret_access_key, 'DescribeRegions', 4)
     Timecop.return
   end
 
@@ -92,8 +89,6 @@ class BaseTest < Test::Unit::TestCase
     ::Timecop.freeze(time)
 
     base = ::AWS::SES::Base.new(
-        server:            'email.us-east-1.amazonaws.com',
-        signature_version: 4,
         access_key_id:     aws_access_key_id,
         secret_access_key: aws_secret_access_key,
         region:            'eu-west-1'


### PR DESCRIPTION
Signature Version 2 will be retired on March 27th, 2021. Let's default to v4, so users wont have to explicitly force this version.