### PR TITLE
Indicate minimum required Ruby version.

### DIFF
--- a/aws-ses.gemspec
+++ b/aws-ses.gemspec
@@ -8,6 +8,8 @@ Gem::Specification.new do |s|
   s.name = "aws-ses".freeze
   s.version = "0.7.1"
 
+  s.required_ruby_version = '>= 2.0.0'
+  
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
   s.authors = ["Drew Blas".freeze, "Marcel Molina Jr.".freeze]


### PR DESCRIPTION
In https://github.com/drewblas/aws-ses/blob/master/lib/aws/ses/base.rb#L223 it calls the "b" method on a String.  This b method was not introduced until version 2 of Ruby.  See https://ruby-doc.org/core-2.0.0/String.html#method-i-b for this methods introduction.  See https://ruby-doc.org/core-1.9.3/String.html where it does not exist.